### PR TITLE
Fixed dependency evaluation test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,8 @@ jobs:
             nox-session: "tests(python='3.11', snakemake='latest')"
 
           # TODO(dfm): Test on Windows - there are currently many failures
-          # - platform: windows-latest
-          #   nox-session: "tests(python='3.11', snakemake='latest')"
+          - platform: windows-latest
+            nox-session: "tests(python='3.11', snakemake='latest')"
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,8 @@ jobs:
             nox-session: "tests(python='3.11', snakemake='latest')"
 
           # TODO(dfm): Test on Windows - there are currently many failures
-          - platform: windows-latest
-            nox-session: "tests(python='3.11', snakemake='latest')"
+          # - platform: windows-latest
+          #   nox-session: "tests(python='3.11', snakemake='latest')"
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,10 +33,11 @@ def snakemake_session(
 
 @snakemake_session
 def tests(session: nox.Session) -> None:
+    session.log(session.posargs)
     session.install(".[test]")
-    args = tuple(*session.posargs)
+    args = session.posargs
     if not args:
-        args = ("-v", "--durations=5")
+        args = ["-v", "--durations=5"]
     session.run("pytest", *args)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,6 @@ def snakemake_session(
 
 @snakemake_session
 def tests(session: nox.Session) -> None:
-    session.log(session.posargs)
     session.install(".[test]")
     args = session.posargs
     if not args:

--- a/src/showyourwork2/workflow/rules/dependencies.smk
+++ b/src/showyourwork2/workflow/rules/dependencies.smk
@@ -2,6 +2,8 @@ import json
 import inspect
 from showyourwork2.dependencies import simplify_dependency_tree
 
+SYW__DAG_FLAG = SYW__WORK_PATHS.flag("dag")
+
 def get_document_dependencies(doc):
     checkpoint_name = utils.rule_name(
         "check", "dependencies", document=doc
@@ -47,6 +49,7 @@ def ensure_all_document_dependencies(*_):
     dag = None
     for level in inspect.stack():
         dag = level.frame.f_locals.get("dag", None)
+        print("*** DAG ***: ", dag)
         if dag is not None:
             break
 
@@ -94,7 +97,7 @@ rule:
     input:
         [get_document_dependencies(doc) for doc in SYW__DOCUMENTS]
     output:
-        touch(SYW__WORK_PATHS.flag("dag"))
+        touch(SYW__DAG_FLAG)
 
 rule:
     name:
@@ -102,7 +105,7 @@ rule:
     message:
         "Saving document dependency tree as JSON"
     input:
-        rules.syw__dag.output,
+        SYW__DAG_FLAG,
         ensure_all_document_dependencies
     output:
         SYW__WORK_PATHS.root / "dependency_tree.json",

--- a/src/showyourwork2/workflow/rules/dependencies.smk
+++ b/src/showyourwork2/workflow/rules/dependencies.smk
@@ -49,7 +49,6 @@ def ensure_all_document_dependencies(*_):
     dag = None
     for level in inspect.stack():
         dag = level.frame.f_locals.get("dag", None)
-        print("*** DAG ***: ", dag)
         if dag is not None:
             break
 

--- a/tests/projects/dependency_tree/.showyourwork/ms.tex.dependencies.json
+++ b/tests/projects/dependency_tree/.showyourwork/ms.tex.dependencies.json
@@ -1,5 +1,0 @@
-{
-  "unlabeled": ["a", "b"],
-  "files": ["c", "d"],
-  "figures": {"x": ["e", "f"], "y": ["g", "h"]}
-}

--- a/tests/projects/dependency_tree/ms.tex
+++ b/tests/projects/dependency_tree/ms.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\usepackage{showyourwork}
+\begin{document}
+Test.
+\variable{h}
+\end{document}

--- a/tests/test_rule_order.py
+++ b/tests/test_rule_order.py
@@ -31,7 +31,7 @@ fix_rule_order(config, workflow)
             # If no prefix is used then snakemake should fail since the rule
             # order is ambiguous.
             with pytest.raises(RuntimeError):
-                run_snakemake(root, "a.txt")
+                run_snakemake(root, "a.txt", copy_using_git=False)
         else:
-            with run_snakemake(root, "a.txt") as result:
+            with run_snakemake(root, "a.txt", copy_using_git=False) as result:
                 assert (result / "a.txt").read_text().strip() == "a"


### PR DESCRIPTION
It seems like there was an issue with evaluation order in the dependency tree test that wasn't hitting just as a fluke. This might have also been the main Windows problem.